### PR TITLE
init parser method abstracted from constructor to avoid TS error

### DIFF
--- a/projects/material-dayjs-adapter/src/lib/adapter/dayjs-date-adapter.ts
+++ b/projects/material-dayjs-adapter/src/lib/adapter/dayjs-date-adapter.ts
@@ -54,17 +54,8 @@ export class DayjsDateAdapter extends DateAdapter<Dayjs> {
               @Optional() @Inject(MAT_DAYJS_DATE_ADAPTER_OPTIONS) private options?: DayJsDateAdapterOptions) {
     super();
 
-    // Initialize DayJS-Parser
-    if (this.shouldUseUtc) {
-      dayjs.extend(utc);
+    this.initializeParser(dateLocale);
     }
-
-    dayjs.extend(LocalizedFormat);
-    dayjs.extend(customParseFormat);
-    dayjs.extend(localeData);
-
-    this.setLocale(dateLocale);
-  }
 
   // TODO: Implement
   setLocale(locale: string) {
@@ -228,5 +219,17 @@ export class DayjsDateAdapter extends DateAdapter<Dayjs> {
   private get shouldUseUtc(): boolean {
     const { useUtc }: DayJsDateAdapterOptions = this.options || {};
     return !!useUtc;
+  }
+
+  private initializeParser(dateLocale: string) {
+    if (this.shouldUseUtc) {
+      dayjs.extend(utc);
+    }
+
+    dayjs.extend(LocalizedFormat);
+    dayjs.extend(customParseFormat);
+    dayjs.extend(localeData);
+
+    this.setLocale(dateLocale);
   }
 }


### PR DESCRIPTION
Moving the accessor call from the constructor itself and moving to an abstracted private method seems to take care of the TS error for me.